### PR TITLE
Removed a method that would expose numpy to the user of Point.

### DIFF
--- a/pyVor/primitives/point.py
+++ b/pyVor/primitives/point.py
@@ -45,13 +45,6 @@ class Point:
             raise ValueError('Dimension mismatch')
         return Vector(*[x - y for x, y in zip(self, p)])
 
-    def to_array(self):
-        """Return a numpy array of the components
-        This will be useful for if we need to build up additional data
-        structures from a point
-        """
-        return self._components
-
     def to_vector(self):
         """Turn the point into a vector from the origin"""
         return self - Point(*[0 for x in self])

--- a/pyVor/tests/testPrimitives.py
+++ b/pyVor/tests/testPrimitives.py
@@ -217,7 +217,7 @@ class PointTestCase(unittest.TestCase):
         # Drew's tests:
         self.assertFalse(self.a == self.b)
         self.assertTrue(self.b == self.b)
-        self.assertTrue(self.c == Point(1, 2, 3))
+        self.assertTrue(Point(1, 2, 3) == Point(1, 2, 3))
         self.assertFalse(self.b == self.c)
         self.assertFalse(self.b == (1, 2))
 
@@ -270,6 +270,11 @@ class PointTestCase(unittest.TestCase):
         self.assertEqual(self.a.to_vector(), Vector(0, 0))
         self.assertEqual(self.b.to_vector(), Vector(1, 2))
         self.assertNotEqual(self.b.to_vector(), Vector(1, 2, 0))
+
+    def test_to_array(self):
+        """Make sure the to_array method does not exist, because it's bad."""
+        with self.assertRaises(AttributeError):
+            some_array = self.b.to_array()
 
 
 class MatrixTestCase(unittest.TestCase):

--- a/pyVor/tests/testPrimitives.py
+++ b/pyVor/tests/testPrimitives.py
@@ -271,11 +271,6 @@ class PointTestCase(unittest.TestCase):
         self.assertEqual(self.b.to_vector(), Vector(1, 2))
         self.assertNotEqual(self.b.to_vector(), Vector(1, 2, 0))
 
-    def test_to_array(self):
-        """Make sure the to_array method does not exist, because it's bad."""
-        with self.assertRaises(AttributeError):
-            some_array = self.b.to_array()
-
 
 class MatrixTestCase(unittest.TestCase):
     """Unit tests for the Matrix class"""


### PR DESCRIPTION
Also a little refactoring of a unit test.
If you want to make a list, just iterate instead. `[*Point(1, 2, 3)]` should even work.
