### PR TITLE
Switch to projective plane

### DIFF
--- a/pyVor/__init__.py
+++ b/pyVor/__init__.py
@@ -1,3 +1,3 @@
-import pyVor.primitives
-from .tests import *
-from .predicates import ccw, incircle
+# import pyVor.primitives
+# from .tests import *
+# from .predicates import ccw, incircle

--- a/pyVor/predicates.py
+++ b/pyVor/predicates.py
@@ -10,7 +10,7 @@ to make vectors / document how we should make vectors.
 from pyVor.primitives import Matrix, Vector, Point
 
 
-def ccw(*vectors, homogeneous=True):
+def ccw(*points, homogeneous=True):
     """tests if triangle a, b, c is oriented counterclockwise.
 
     Returns 1 if ccw, 0 if colinear, -1 if cw.
@@ -20,9 +20,10 @@ def ccw(*vectors, homogeneous=True):
     the other points appear to be well-oriented according
     to the (n-1)-dimensional test.
     """
-    # if not homogeneous:
-
-    m = Matrix(*[vector.lift() for vector in vectors])
+    if not homogeneous:
+        m = Matrix(*[pt.lift(lambda v: 1).to_vector() for pt in points])
+    else:
+        m = Matrix(*[pt.to_vector() for pt in points])
     return m.sign_det()
 
 

--- a/pyVor/predicates.py
+++ b/pyVor/predicates.py
@@ -21,10 +21,10 @@ def ccw(*points, homogeneous=True):
     to the (n-1)-dimensional test.
     """
     if not homogeneous:
-        m = Matrix(*[pt.lift(lambda v: 1).to_vector() for pt in points])
+        mtrx = Matrix(*[pt.lift(lambda v: 1).to_vector() for pt in points])
     else:
-        m = Matrix(*[pt.to_vector() for pt in points])
-    return m.sign_det()
+        mtrx = Matrix(*[pt.to_vector() for pt in points])
+    return mtrx.sign_det()
 
 
 def incircle(*points, homogeneous=True):
@@ -42,14 +42,15 @@ def incircle(*points, homogeneous=True):
 
     if homogeneous:
         # The points already have homogeneous coordinates
-        vectors = [p[:-1] - Point(*([0] * (len(p) - 1))) for p in points]
-        h_lifts = [p[-1] for p in points]
+        vectors = [pt - Point(*([0] * len(pt))) for pt in points]
     else:
         # We'll give each point a homogeneous coordinate of 1
-        vectors = [p - Point(*([0] * len(p))) for p in points]
-        h_lifts = [1] * len(points)
+        vectors = [(pt - Point(*([0] * len(pt)))).lift() for pt in points]
 
-    vectors = [vectors[i].lift(lambda v: v.norm_squared())
-               .lift(lambda v: h_lifts[i]) for i in range(len(vectors))]
-
-    return Matrix(*vectors).sign_det()
+    vectors = [vector.lift(lambda v: v[:-1].norm_squared())
+               for vector in vectors]
+    # At this point we could switch the last two elements of each
+    # vector to get the matrix we want to test. But we can
+    # also just use the fact that if you swap 2 rows of a
+    # matrix, the sign of the determinant is flipped. So:
+    return - Matrix(*vectors).sign_det()

--- a/pyVor/predicates.py
+++ b/pyVor/predicates.py
@@ -6,30 +6,49 @@ It also has basic stuff like 'lift' and 'norm', and also a thing
 to make vectors / document how we should make vectors.
 """
 
-import numpy as np
 # from scipy import linalg # supposedly faster, but doesn't have everything
-from numpy import linalg  # for accurate sign of det, hopefully
-from pyVor.primitives import Matrix
-from pyVor.primitives import Vector
+from pyVor.primitives import Matrix, Vector, Point
 
 
-def ccw(*vectors):
+def ccw(*vectors, homogeneous=True):
     """tests if triangle a, b, c is oriented counterclockwise.
 
     Returns 1 if ccw, 0 if colinear, -1 if cw.
 
-    Also does the scary analogous n-dimensional test.
+    Also does the scary analogous n-dimensional test, which
+    essentially tests if, from the perspective of the last point,
+    the other points appear to be well-oriented according
+    to the (n-1)-dimensional test.
     """
+    # if not homogeneous:
+
     m = Matrix(*[vector.lift() for vector in vectors])
-    return int(np.sign(m.det()))
+    return m.sign_det()
 
 
-def incircle(*points):  # a, b, c, d):
+def incircle(*points, homogeneous=True):
     """In R^2, is the last argument inside the circle defined by the
     previous arguments?
     1 if inside, -1 if outside, and 0 if all cocircular.
+
+    The points are interpreted as having extended homogenious
+    coordinates unless homogeneous=False is passed.
     """
-    vectors = [p - Vector(*[0 for x in p]) for p in points]
-    m = Matrix(*[vector.lift(lambda v: v.norm_squared())
-                 .lift() for vector in vectors])
-    return int(np.sign(m.det()))
+    # if debug and homogeneous:
+    #     # Checking for human error. Eventually we can turn debug off.
+    #     if not sum([p[-1] == 1 or p[-1] == 0 for p in points]):
+    #         raise ValueError("These points are not homogeneous!")
+
+    if homogeneous:
+        # The points already have homogeneous coordinates
+        vectors = [p[:-1] - Point(*([0] * (len(p) - 1))) for p in points]
+        h_lifts = [p[-1] for p in points]
+    else:
+        # We'll give each point a homogeneous coordinate of 1
+        vectors = [p - Point(*([0] * len(p))) for p in points]
+        h_lifts = [1] * len(points)
+
+    vectors = [vectors[i].lift(lambda v: v.norm_squared())
+               .lift(lambda v: h_lifts[i]) for i in range(len(vectors))]
+
+    return Matrix(*vectors).sign_det()

--- a/pyVor/primitives/matrix.py
+++ b/pyVor/primitives/matrix.py
@@ -66,10 +66,10 @@ class Matrix:
         return float(np.linalg.det(self._columns))
 
     def sign_det(self):
-        """Returns just the sign of the determinant.
+        """Returns just the sign of the determinant (as an int in [-1, 0, 1])
 
-        Someday this might be more efficient than Matrix.det, and so if you only
-        want the sign, then you should use this one.
+        Someday this might be more efficient than Matrix.det, and so if you
+        only want the sign, then you should use this one.
         """
         return int(np.sign(self.det()))
 
@@ -104,5 +104,4 @@ class Matrix:
             return Matrix(*[Vector(*i)
                           for i in np.linalg.inv(self._columns).T])
         except np.linalg.linalg.LinAlgError as e:
-            #e.args += ("Attempted to invert a singular matrix",)
             raise ValueError("Matrix is not invertible") from e

--- a/pyVor/primitives/matrix.py
+++ b/pyVor/primitives/matrix.py
@@ -65,6 +65,14 @@ class Matrix:
         """Return determinant of matrix"""
         return float(np.linalg.det(self._columns))
 
+    def sign_det(self):
+        """Returns just the sign of the determinant.
+
+        Someday this might be more efficient than Matrix.det, and so if you only
+        want the sign, then you should use this one.
+        """
+        return int(np.sign(self.det()))
+
     def __add__(self, other):
         """Add this matrix with another matrix"""
         return Matrix(*[Vector(*i) for i in
@@ -96,4 +104,5 @@ class Matrix:
             return Matrix(*[Vector(*i)
                           for i in np.linalg.inv(self._columns).T])
         except np.linalg.linalg.LinAlgError as e:
-            raise ValueError("Inverse does not exist")
+            #e.args += ("Attempted to invert a singular matrix",)
+            raise ValueError("Matrix is not invertible") from e

--- a/pyVor/primitives/point.py
+++ b/pyVor/primitives/point.py
@@ -26,7 +26,11 @@ class Point:
 
     def __getitem__(self, val):
         """Be able to access an individual component of a point"""
-        return self._components[val]
+        if isinstance(val, slice):
+            # This part could conceivably throw ValueError("Empty Point")
+            return Point(*self._components[val])
+        else:
+            return self._components[val]
 
     def __iter__(self):
         """So that we can iterate over the components of a point"""
@@ -40,7 +44,7 @@ class Point:
             all([p[i] == self[i] for i in range(len(p))])
 
     def __sub__(self, p):
-        """We need to implement this once we have a vector class"""
+        """Subtract two points to obtain a Vector"""
         if len(self) != len(p):
             raise ValueError('Dimension mismatch')
         return Vector(*[x - y for x, y in zip(self, p)])

--- a/pyVor/primitives/vector.py
+++ b/pyVor/primitives/vector.py
@@ -8,7 +8,7 @@ class Vector:
     def __init__(self, *components):
         """Store componements in a numpy array under the hood"""
         if not components:
-            raise ValueError("Dimension Mismatch")
+            raise ValueError("Empty Vector")
         self._components = np.array(components)
 
     def __repr__(self):
@@ -25,7 +25,11 @@ class Vector:
 
     def __getitem__(self, val):
         """Be able to access an individual component of a vector"""
-        return self._components[val]
+        if isinstance(val, slice):
+            # This part could conceivably throw ValueError("Empty Point")
+            return Vector(*self._components[val])
+        else:
+            return self._components[val]
 
     def __iter__(self):
         """So that we can iterate over the components of a vector"""

--- a/pyVor/tests/testPredicates.py
+++ b/pyVor/tests/testPredicates.py
@@ -21,9 +21,18 @@ class PredicatesTestCase(unittest.TestCase):
         self.r2east = Point(1, 0)
         self.r2west = Point(-1, 0)
         self.r2orig = Point(0, 0)
+        # Now the homogeneous version of the same thing
+        # (We use the plane z=1 to represent the projective
+        # plane in a roundabout way. Points with z=0 are
+        # essentially infinitely far away. Cool, right?)
+        self.homo_north = Point(0, 1, 1)
+        self.homo_south = Point(0, -1, 1)
+        self.homo_east = Point(1, 0, 1)
+        self.homo_west = Point(-1, 0, 1)
+        self.homo_orig = Point(0, 0, 1)
 
-    def test_incircle(self):
-        """Test the incircle predicate."""
+    def test_incircle_plane(self):
+        """Test the incircle predicate in the plane."""
         # TODO - Add tests with extended homogeneous coordinates
 
         # Not sure if I like this part, but I don't have time to make
@@ -32,37 +41,83 @@ class PredicatesTestCase(unittest.TestCase):
         b = Point(0, 1)
         c = Point(-1, 0)
         d = Point(0, 0)
-        self.assertTrue(incircle(a, b, c, d) == 1)
-        self.assertTrue(incircle(a, b, d, c) == -1)
-        self.assertTrue(incircle(a, b, c, c) == 0)
+        self.assertTrue(incircle(a, b, c, d, homogeneous=False) == 1)
+        self.assertTrue(incircle(a, b, d, c, homogeneous=False) == -1)
+        self.assertTrue(incircle(a, b, c, c, homogeneous=False) == 0)
 
         r2far_east = Point(50, -0.5)
 
         # circle of radius 0... ought to be 0 (co-circular)
         self.assertEqual(incircle(self.r2east, self.r2east, self.r2east,
-                                  self.r2east), 0)
+                                  self.r2east, homogeneous=False), 0)
 
         # The origin is in fact inside the (counterclockwise) unit circle
         self.assertEqual(incircle(self.r2east, self.r2north, self.r2west,
-                                  self.r2orig), 1)
+                                  self.r2orig, homogeneous=False), 1)
 
         # SHOULD depend on orientation of circle, so we can
         # have stuff like inside-out circles
         self.assertNotEqual(incircle(self.r2east, self.r2west, self.r2north,
-                                     self.r2orig),
+                                     self.r2orig, homogeneous=False),
                             incircle(self.r2west, self.r2east, self.r2north,
-                                     self.r2orig))
+                                     self.r2orig, homogeneous=False))
         self.assertNotEqual(incircle(self.r2east, self.r2north, self.r2west,
-                                     self.r2orig),
+                                     self.r2orig, homogeneous=False),
                             incircle(self.r2north, self.r2east, self.r2west,
-                                     self.r2orig))
+                                     self.r2orig, homogeneous=False))
 
         # Finitely faraway pt not in (counterclockwise) unit circle
         self.assertEqual(incircle(self.r2north, self.r2west, self.r2east,
-                                  r2far_east), -1)
+                                  r2far_east, homogeneous=False), -1)
         # Finitely faraway pt is in the clockwise (inside-out) unit circle
         self.assertEqual(incircle(self.r2west, self.r2north, self.r2east,
-                                  r2far_east), 1)
+                                  r2far_east, homogeneous=False), 1)
+
+    def test_incircle_projective(self):
+        """Tests incircle on points with homogeneous coordinates
+        (representing points in the projective plane)
+        """
+        far_east_finite = Point(50, 0, 1)
+        far_east_infinite = Point(1, 0, 0)
+
+        # Counterclockwise circle around origin contains origin:
+        self.assertEqual(incircle(self.homo_east, self.homo_north,
+                                  self.homo_south, self.homo_orig), 1)
+        # But it shouldn't contain any faraway point:
+        self.assertEqual(incircle(self.homo_east, self.homo_north,
+                                  self.homo_south, far_east_finite), -1)
+        self.assertEqual(incircle(self.homo_east, self.homo_north,
+                                  self.homo_south, far_east_infinite), -1)
+        # And of course, another point on the unit circle should be cocircular:
+        self.assertEqual(incircle(self.homo_east, self.homo_north,
+                                  self.homo_south, self.homo_west), 0)
+
+        # Clockwise circle around origin does not contain origin:
+        self.assertEqual(incircle(self.homo_north, self.homo_east,
+                                  self.homo_south, self.homo_orig), -1)
+        # But it SHOULD contain faraway points:
+        self.assertEqual(incircle(self.homo_north, self.homo_east,
+                                  self.homo_south, far_east_finite), 1)
+        self.assertEqual(incircle(self.homo_north, self.homo_east,
+                                  self.homo_south, far_east_infinite), 1)
+        # Cocircular stuff should still be cocircular:
+        self.assertEqual(incircle(self.homo_north, self.homo_east,
+                                  self.homo_south, self.homo_west), 0)
+
+        # Check for subtle arithmetic errors:
+        self.assertEqual(incircle(Point(0, -10, 1),
+                                  Point(0, 0, 1),
+                                  Point(-0.001, 10, 1),
+                                  Point(-0.0005, 10, 1)),
+                         -1)
+
+        # Points at infinity should be colinear and thus also cocircular
+        self.assertEqual(incircle(Point(1, 0, 0),
+                                  Point(-1, 1, 0),
+                                  Point(1, 1, 0),
+                                  Point(2, 1, 0)),
+                         0)
+
 
     def test_ccw(self):
         """Right now this only tests ccw for 1 and 2 dimensions."""

--- a/pyVor/tests/testPredicates.py
+++ b/pyVor/tests/testPredicates.py
@@ -31,7 +31,7 @@ class PredicatesTestCase(unittest.TestCase):
         self.homo_west = Point(-1, 0, 1)
         self.homo_orig = Point(0, 0, 1)
 
-    def test_incircle_plane(self):
+    def test_incircle_euclidean(self):
         """Test the incircle predicate in the plane."""
         # TODO - Add tests with extended homogeneous coordinates
 
@@ -118,44 +118,91 @@ class PredicatesTestCase(unittest.TestCase):
                                   Point(2, 1, 0)),
                          0)
 
-
-    def test_ccw(self):
+    def test_ccw_euclidean(self):
         """Right now this only tests ccw for 1 and 2 dimensions."""
         # one-dimensional test.
 
-        one_dim_high = Vector(1)
-        one_dim_low = Vector(0)
+        one_dim_high = Point(1)
+        one_dim_low = Point(0)
         # I don't much care which way is negative, but one had better
         # be positive and the other negative. And they'd better be
         # ints.
-        self.assertEqual((ccw(one_dim_high, one_dim_low) *
-                          ccw(one_dim_low, one_dim_high)),
+        self.assertEqual((ccw(one_dim_high, one_dim_low, homogeneous=False) *
+                          ccw(one_dim_low, one_dim_high, homogeneous=False)),
                          -1)
+        self.assertIsInstance((ccw(one_dim_high, one_dim_low,
+                                   homogeneous=False) *
+                               ccw(one_dim_low, one_dim_high,
+                                   homogeneous=False)),
+                              int)
+
         # co-hyperplanar --> 0
-        self.assertEqual(ccw(one_dim_high, one_dim_high), 0)
+        self.assertEqual(ccw(one_dim_high, one_dim_high, homogeneous=False), 0)
 
         # Now for 2D stuff:
 
         # Invariance under rotation of args
-        self.assertEqual(ccw(self.r2north, self.r2east, self.r2south),
-                         ccw(self.r2south, self.r2north, self.r2east))
+        self.assertEqual(ccw(self.r2north, self.r2east, self.r2south,
+                             homogeneous=False),
+                         ccw(self.r2south, self.r2north, self.r2east,
+                             homogeneous=False))
 
-        self.assertEqual(ccw(self.r2north, self.r2east, self.r2south), -1)
-        self.assertEqual(ccw(self.r2east, self.r2south, self.r2west), -1)
-        self.assertEqual(ccw(self.r2south, self.r2north, self.r2orig), 0)
-        self.assertEqual(ccw(self.r2east, self.r2orig, self.r2east), 0)
-        self.assertEqual(ccw(self.r2west, self.r2east, self.r2south), -1)
-        self.assertEqual(ccw(self.r2west, self.r2south, self.r2north), 1)
+        self.assertEqual(ccw(self.r2north, self.r2east, self.r2south,
+                             homogeneous=False), -1)
+        self.assertEqual(ccw(self.r2east, self.r2south, self.r2west,
+                             homogeneous=False), -1)
+        self.assertEqual(ccw(self.r2south, self.r2north, self.r2orig,
+                             homogeneous=False), 0)
+        self.assertEqual(ccw(self.r2east, self.r2orig, self.r2east,
+                             homogeneous=False), 0)
+        self.assertEqual(ccw(self.r2west, self.r2east, self.r2south,
+                             homogeneous=False), -1)
+        self.assertEqual(ccw(self.r2west, self.r2south, self.r2north,
+                             homogeneous=False), 1)
 
         # Swapping two args flips the sign
-        self.assertEqual(ccw(self.r2west, self.r2south, self.r2north),
-                         -ccw(self.r2south, self.r2west, self.r2north))
-        self.assertEqual(ccw(self.r2west, self.r2east, self.r2orig),
-                         -ccw(self.r2east, self.r2west, self.r2orig))
+        self.assertEqual(ccw(self.r2west, self.r2south, self.r2north,
+                             homogeneous=False),
+                         -ccw(self.r2south, self.r2west, self.r2north,
+                              homogeneous=False))
+        self.assertEqual(ccw(self.r2west, self.r2east, self.r2orig,
+                             homogeneous=False),
+                         -ccw(self.r2east, self.r2west, self.r2orig,
+                              homogeneous=False))
         # Warn us when we make non-square matrices
         self.assertRaises(Exception, ccw, self.r2west, self.r2south,
-                          self.r2north, self.r2east)
-        self.assertRaises(Exception, ccw, self.r2orig, self.r2south)
+                          self.r2north, self.r2east, homogeneous=False)
+        self.assertRaises(Exception, ccw, self.r2orig, self.r2south,
+                          homogeneous=False)
+
+    def test_ccw_projective(self):
+        """Tests ccw with extended homogeneous coordinates"""
+        # Make sure simple stuff works
+        # Should be counterclockwise:
+        self.assertEqual(ccw(self.homo_north, self.homo_south, self.homo_east),
+                         1)
+        # Should be colinear:
+        self.assertEqual(ccw(Point(1, 0, 1), Point(0, 0, 1), Point(-1, 0, 1)),
+                         0)
+        # Should be clockwise:
+        self.assertEqual(ccw(self.homo_north, self.homo_east, self.homo_south),
+                         -1)
+
+        # Now try some weird stuff
+
+        # Tests involving one infinitely distance point:
+        self.assertEqual(ccw(Point(1, 0, 1), Point(0, 0, 1), Point(0, 1, 0)),
+                         -1)
+
+        # Tests involving two infinitely distance points:
+        self.assertEqual(ccw(Point(1, 0, 0), Point(0, 0, 1), Point(0, 1, 0)),
+                         -1)
+        self.assertEqual(ccw(Point(0, 1, 0), Point(0, 0, 1), Point(1, 0, 0)),
+                         1)
+
+        # Points at infinity are colinear:
+        self.assertEqual(ccw(Point(1, 0, 0), Point(-1, 0, 0), Point(0, 1, 0)),
+                         0)
 
 
 if __name__ == "__main__":

--- a/pyVor/tests/testPrimitives.py
+++ b/pyVor/tests/testPrimitives.py
@@ -160,6 +160,8 @@ class VectorTestCase(unittest.TestCase):
         with self.assertRaises(IndexError):
             my_vector[len(my_vector)]
 
+        self.assertIsInstance(my_vector[:-1], Vector)
+
     def test_norm_squared(self):
         """Make sure that the norm_squared is right"""
         zero_v = self.zero_v

--- a/pyVor/tests/testPrimitives.py
+++ b/pyVor/tests/testPrimitives.py
@@ -188,7 +188,7 @@ class VectorTestCase(unittest.TestCase):
     def test_vector_lift(self):
         """Test to make sure that we can lift a Vector"""
         # Make sure that lifting a vector results in a Vector
-        self.assertTrue(type(Vector(1, 1, 1).lift()) == Vector)
+        self.assertIsInstance(Vector(1, 1, 1).lift(), Vector)
 
         # Define a function to test lifting with
         def f(x):
@@ -240,7 +240,7 @@ class PointTestCase(unittest.TestCase):
         self.assertFalse(self.c.lift(f) == Point(1, 2, 3))
 
         # Make sure that lifting a Point returns a Point
-        self.assertTrue(type(self.b.lift(f)) == Point)
+        self.assertIsInstance(self.b.lift(f), Point)
 
     def test_length(self):
         """Test to see if length of a point makes sense"""
@@ -412,7 +412,7 @@ class MatrixTestCase(unittest.TestCase):
     def test_matrix_sign_det(self):
         """Tests that sign_det returns the sign of the determinant.
 
-        (Rather, sign_det should return an integer with the same sign as the 
+        (Rather, sign_det should return an integer with the same sign as the
         determinant.)
         """
         ident_3 = Matrix(Vector(1, 0, 0),

--- a/pyVor/tests/testPrimitives.py
+++ b/pyVor/tests/testPrimitives.py
@@ -258,8 +258,11 @@ class PointTestCase(unittest.TestCase):
             # I want a warning when I accidentally try to set values:
             self.b[-1] = 10
 
+        self.assertIsInstance(self.a[:-1], Point)
+
     def test_subtraction(self):
         """Test point subtraction"""
+        self.assertIsInstance(self.b - self.a, Vector)
         self.assertTrue(self.b - self.b == Vector(0, 0))
         self.assertTrue(self.b - self.a == Vector(1, 2))
         self.assertFalse(self.b - self.b == Point(0, 0))
@@ -405,6 +408,31 @@ class MatrixTestCase(unittest.TestCase):
                          Matrix(Vector(1, 0, 0),
                                 Vector(0, 1, 0),
                                 Vector(0, 0, 1)))
+
+    def test_matrix_sign_det(self):
+        """Tests that sign_det returns the sign of the determinant.
+
+        (Rather, sign_det should return an integer with the same sign as the 
+        determinant.)
+        """
+        ident_3 = Matrix(Vector(1, 0, 0),
+                         Vector(0, 1, 0),
+                         Vector(0, 0, 1))
+        # The following are just some cases where it's easy
+        # to do the math in your head.
+        self.assertEqual(ident_3.sign_det(),
+                         1)
+        self.assertEqual((ident_3 - ident_3).sign_det(),
+                         0)
+        # (A lower-triangular matrix. And don't forget it.)
+        self.assertEqual(Matrix(Vector(1, 2, 3),
+                                Vector(0, -12, 5),
+                                Vector(0, 0, 0.001)).sign_det(),
+                         -1)
+
+        self.assertIsInstance(Matrix(Vector(1, 2),
+                                     Vector(3, 4)).sign_det(),
+                              int)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
You can pass `homogeneous=False` to the predicates if you really want, but otherwise we're flying in the projective plane. And it's great.
